### PR TITLE
Added node versions still supported (either LTS or maintenance) to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: true
 language: node_js
 node_js:
 - node
+- 6
+- 4
 before_install:
 - chmod +x .travis/build.sh
 script: .travis/build.sh


### PR DESCRIPTION
To prevent issues similar to #31 being introduced this commit adds explicit node runtime versions to the travis.yml config alongside the latest. Versions 4, 6 and latest are [supported](https://github.com/nodejs/LTS) where for now latest === 8.