### PR TITLE
Set ContentType to "application/json" when write s3 object

### DIFF
--- a/lib/bin/dbRecord.js
+++ b/lib/bin/dbRecord.js
@@ -47,6 +47,7 @@ class DbRecord {
                 params.Body = change.data;
                 params.ServerSideEncryption = 'AES256';
                 params.StorageClass = 'STANDARD_IA';
+                params.ContentType = "application/json";
             }
 
             s3[req](params, (err) => {


### PR DESCRIPTION
Hi,

I submit a little PR to set the content-type to "application/json" instead of "application/octet-stream".

This change allows the browser to directly display the content rather than offering the download window. Useful for debugging