### PR TITLE
Fix JSON.stringified Binary data on restore resulting in InvalidParameterType error

### DIFF
--- a/lib/bin/restoreDynamoDb.js
+++ b/lib/bin/restoreDynamoDb.js
@@ -72,6 +72,13 @@ class RestoreDynamoDb {
             dParams.RequestItems[this.DbTable] = [];
 
             if (!version.DeletedMarker) {
+                Object.keys(fileContents).forEach(attributeName => {
+                    // Fix JSON.stringified Binary data
+                    let attr = fileContents[attributeName];
+                    if (attr.B && attr.B.type && (attr.B.type === 'Buffer') && attr.B.data) {
+                        attr.B = Buffer.from(attr.B.data);
+                    }
+                });
                 action.PutRequest = {
                     Item: fileContents
                 };


### PR DESCRIPTION
This fix addresses an error when restoring binary data that has been JSON.stringified to look like this:
`"text":{"B":{"type":"Buffer","data":[1,2,2,0,120,107,142,198,202,199,86,173,163,235,190,18,213,63,147,177,0,244,159,89,100,38,251,211]}}`

Before this fix, restoring resulted in this error: `InvalidParameterType`
Solves Issue #51 and tested on my staging environment.