### PR TITLE
Support KEYS_ONLY DynamoDB Streams

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+.git/
+.gitattributes
+yarn.lock
+.travis/
+.travis.yml

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ backup.incremental();
 
 The DynamoDB Stream StreamViewType needs to be one of `NEW_IMAGE`, `NEW_AND_OLD_IMAGES`, or `KEYS_ONLY`.
 
+Note that [DynamoDB Streams does not support encryption at rest](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/encryption-before-you-start.html).
+
 ```javascript
 const Backup = require('dynamodb-backup-restore').Backup;
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ backup.incremental();
 ```
 
 ### AWS Lambda based incremental backup
+
+The DynamoDB Stream StreamViewType needs to be one of `NEW_IMAGE`, `NEW_AND_OLD_IMAGES`, or `KEYS_ONLY`.
+
 ```javascript
 const Backup = require('dynamodb-backup-restore').Backup;
 
@@ -79,9 +82,12 @@ module.exports.handler = (event, context, callback) => {
     }
     else {
         let config = {
-            S3Bucket: 'STRING_VALUE', /* required */
-            S3Region: 'STRING_VALUE', /* required */
-            S3Prefix: 'STRING_VALUE'  /* optional */
+            S3Bucket:     'STRING_VALUE', /* required */
+            S3Region:     'STRING_VALUE', /* required */
+            S3Encryption: 'STRING_VALUE', /* optional */
+            S3Prefix:     'STRING_VALUE', /* optional */
+            DbTable:      'STRING_VALUE', /* required if stream is KEYS_ONLY, ignored otherwise */
+            DbRegion:     'STRING_VALUE', /* required if stream is KEYS_ONLY, ignored otherwise */
         };
         let backup = new Backup(config);
         backup.fromDbStream(event.Records).then(() => {

--- a/lib/backup.js
+++ b/lib/backup.js
@@ -13,23 +13,32 @@ class Backup {
     }
 
     fromDbStream(records) {
-        let allRecords = records.reduce((allRecords, action) => {
+        const addDataForEvents = ['INSERT', 'MODIFY'];
+        return records.reduce((allRecords, action) => allRecords.then(allRecords => {
             let id = JSON.stringify(action.dynamodb.Keys);
             allRecords[id] = allRecords[id] || [];
-            let change = {
-                keys: id,
-                data: JSON.stringify(action.dynamodb.NewImage),
-                event: action.eventName
-            };
-            allRecords[id].push(change);
-            
-            return allRecords;
-        }, {});
-        let promises = [];
-        Object.keys(allRecords).forEach(key => {
-            promises.push(this.dbRecord.backup(allRecords[key], true));
-        });
-        return Promise.all(promises)
+            let pdata = Promise.resolve({});
+            if (action.dynamodb.NewImage) {
+                pdata = Promise.resolve(action.dynamodb.NewImage);
+            } else if (addDataForEvents.includes(action.eventName)) {
+                try {
+                    pdata = this.dbInstanceData.getItem(action.dynamodb.Keys);
+                } catch (e) {
+                    return allRecords;
+                }
+            }
+            return pdata.then(data => {
+                let change = {
+                    keys: id,
+                    data: JSON.stringify(data),
+                    event: action.eventName
+                };
+                allRecords[id].push(change);
+                
+                return allRecords;
+            });
+        }), Promise.resolve({}))
+            .then(allRecords => Promise.all(Object.keys(allRecords).map(key => this.dbRecord.backup(allRecords[key], true))))
             .catch(err => {
                 throw err;
             });

--- a/lib/bin/dbInstanceData.js
+++ b/lib/bin/dbInstanceData.js
@@ -22,6 +22,22 @@ class DbInstanceData {
             });
     }
 
+    getItem(Key) {
+        let dynamodb = new AWS.DynamoDB({ region: this.DbRegion });
+        let params = {
+            Key,
+            TableName: this.DbTable,
+            ConsistentRead: true
+        };
+        return dynamodb.getItem(params).promise()
+            .then(data => {
+                if (data && data.Item) {
+                    return data.Item;
+                }
+                return {}
+            });
+    }
+
     getTableKeys() {
         return new Promise((resolve, reject) => {
             let dynamoDb = new AWS.DynamoDB({ region: this.DbRegion });


### PR DESCRIPTION
DynamoDB Streams does not support encryption at rest.
https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/encryption-before-you-start.html

This PR allows the use of this backup solution if used in a setting where sensitive data needs to be encrypted at rest. If the keys of the DynamoDB table are not sensitive information they can be sent on the stream, the lambda can then fetch the full entry and write it to S3. No sensitive data is stored unencrypted.

The only potential issue I can think of is if an item is updated multiple times quickly the lambda may receive an item that is too new. But it's still better than nothing :)

See attached sequence diagram for what I mean.
![screenshot from 2018-08-31 10-39-18](https://user-images.githubusercontent.com/357601/44883094-1c3f7880-ad0a-11e8-8a56-f9e5741d373a.png)
