### PR TITLE
Switch lambda runtime from nodejs4.3 to nodejs10.x

### DIFF
--- a/lib/bin/infrastructure/lambda.js
+++ b/lib/bin/infrastructure/lambda.js
@@ -225,7 +225,7 @@ class LambdaInfrastructure {
                 FunctionName: this.LambdaName,
                 Handler: 'index.handler',
                 Role: roleArn,
-                Runtime: 'nodejs4.3',
+                Runtime: 'nodejs10.x',
                 Description: 'Backup Lambda',
                 MemorySize: this.LambdaMemorySize,
                 Timeout: this.LambdaTimeout


### PR DESCRIPTION
I have tested this change in our AWS account, and the continuous backups (done via that Lambda and an associated DynamoDB trigger) seem to work fine using NodeJS 10.x.