### PR TITLE
Fixed memory leak issue while retrieving dynamodb records

### DIFF
--- a/lib/bin/dbInstanceData.js
+++ b/lib/bin/dbInstanceData.js
@@ -51,71 +51,55 @@ class DbInstanceData {
         });
     }
 
-    getRecords(keys) {
-        return new Promise((resolve, reject) => {
-
-            let dynamodb = new AWS.DynamoDB({ region: this.DbRegion });
-            let params = {
-                TableName: this.DbTable,
-                ExclusiveStartKey: null,
-                Limit: 100,
-                Select: 'ALL_ATTRIBUTES'
-            };
-
-            var numberOfRecords = 0;
-
-            function recursiveCall(params) {
-                return new Promise((rs, rj) => {
-
-                    dynamodb.scan(params, (err, data) => {
-                        if (err) {
-                            return rj(err);
-                        }
-                        
-                        let records = [];
-                        data.Items.forEach((item) => {
-                            let id = {};
-                            keys.forEach(key => {
-                                id[key.AttributeName] = item[key.AttributeName];
-                            });
-
-                            let record = {
-                                keys: JSON.stringify(id),
-                                data: JSON.stringify(item),
-                                event: 'INSERT'
-                            };
-                            records.push(record);
-                        });
-
-                        let promises = [];
-                        records.forEach(record => {
-                            promises.push(this.dbRecord.backup([record]));
-                        });
-                        Promise.all(promises)
-                            .then(() => {
-                                numberOfRecords += data.Items.length;
-                                console.log('Retrieved ' + data.Items.length + ' records; total at ' + numberOfRecords + ' records.');
-                                if (data.LastEvaluatedKey) {
-                                    params.ExclusiveStartKey = data.LastEvaluatedKey;
-                                    return recursiveCall.call(this, params).then(() => rs());
-                                } 
-                                return rs();
-                            })
-                            .catch(err => {
-                                rj(err);
-                            });
-                    });
-                });
-            }
-
-            recursiveCall.call(this, params)
-            .then(data => { 
-                resolve() 
-            }).catch(err =>{
-                reject(err);
+    async getRecords(keys) {
+        let dynamodb = new AWS.DynamoDB({ region: this.DbRegion });
+        let params = {
+          TableName: this.DbTable,
+          ExclusiveStartKey: null,
+          Limit: 100,
+          Select: "ALL_ATTRIBUTES",
+        };
+    
+        var numberOfRecords = 0;
+    
+        let LastEvaluatedKey = null;
+        do {
+          params.ExclusiveStartKey = LastEvaluatedKey;
+          let data = await dynamodb.scan(params).promise();
+    
+          let records = [];
+          data.Items.forEach((item) => {
+            let id = {};
+            keys.forEach((key) => {
+              id[key.AttributeName] = item[key.AttributeName];
             });
-        });
+    
+            let record = {
+              keys: JSON.stringify(id),
+              data: JSON.stringify(item),
+              event: "INSERT",
+            };
+            records.push(record);
+          });
+    
+          let promises = [];
+          records.forEach((record) => {
+            promises.push(this.dbRecord.backup([record]));
+          });
+          await Promise.all(promises);
+    
+          numberOfRecords += data.Items.length;
+          console.log(
+            "Retrieved " +
+              data.Items.length +
+              " records; total at " +
+              numberOfRecords +
+              " records."
+          );
+          LastEvaluatedKey = data.LastEvaluatedKey;
+        } while (LastEvaluatedKey);
     }
+    
 
 }
 


### PR DESCRIPTION
There is a memory leak while using recursion. The process crashes when running for a large number of records. Making it iterative, so that there are no closures preventing variable cleanup. Added async/await syntax for get records